### PR TITLE
Reorganized ozfortress configs

### DIFF
--- a/configs/compctrl-matches.cfg
+++ b/configs/compctrl-matches.cfg
@@ -346,7 +346,8 @@
 			}
 		}
 	}
-	"ozfortress-stopwatch"
+
+	"owl-push"
 	{
 		"periods"
 		{
@@ -354,10 +355,8 @@
 			{
 				"name"					"first half"
 				
-				"stopwatch"				"1"
-				
-				"manual-scoring"		"1"
-				"maxrounds"				"1"
+				"timelimit"				"30"
+				"winlimit"				"3"
 				
 				"end-game"				"0"
 				"next-period"			"2"
@@ -368,33 +367,17 @@
 				
 				"switch-teams-to-begin"	"1"
 				
-				"stopwatch"				"1"
-				
-				"manual-scoring"		"1"
-				"maxrounds"				"1"
+				"timelimit"				"30"
+				"winlimit"				"5"
 				
 				"end-game"				"1"
-				"allow-tie"				"0"
-				"next-period"			"3"
-			}
-			"3"
-			{
-				"name"					"overtime"
-				
-				"switch-teams-to-begin"	"1"
-				
-				"stopwatch"				"1"
-				
-				"manual-scoring"		"1"
-				"windifference"			"1"
-				
-				"end-game"				"1"
-				"allow-tie"				"0"
-				"next-period"			"3"
+				"allow-tie"				"1"
+				"next-period"			"2"
 			}
 		}
 	}
-	"ozfortress-standard"
+	
+	"owl-push-finals"
 	{
 		"periods"
 		{
@@ -435,7 +418,106 @@
 			}
 		}
 	}
-	"ozfortress-koth"
+	
+	"owl-koth"
+	{
+		"periods"
+		{
+			"1"
+			{
+				"name"					"first half"
+				
+				"winlimit"				"3"
+				
+				"end-game"				"0"
+				"next-period"			"2"
+			}
+			"2"
+			{
+				"name"					"second half"
+				
+				"switch-teams-to-begin"	"1"
+				
+				"winlimit"				"4"
+				
+				"end-game"				"1"
+				"allow-tie"				"1"
+				"next-period"			"2"
+			}
+		}
+	}
+	
+	"owl-koth-finals"
+	{
+		"periods"
+		{
+			"1"
+			{
+				"name"					"first half"
+				
+				"winlimit"				"3"
+				
+				"end-game"				"0"
+				"next-period"			"2"
+			}
+			"2"
+			{
+				"name"					"second half"
+				
+				"switch-teams-to-begin"	"1"
+				
+				"winlimit"				"4"
+				
+				"end-game"				"1"
+				"allow-tie"				"0"
+				"next-period"			"3"
+			}
+			"3"
+			{
+				"name"					"overtime"
+				
+				"switch-teams-to-begin"	"1"
+				
+				"windifference"			"1"
+				
+				"end-game"				"1"
+				"allow-tie"				"0"
+				"next-period"			"3"
+			}
+		}
+	}
+	
+	"ozf-push"
+	{
+		"periods"
+		{
+			"1"
+			{
+				"name"					"regulation"
+				
+				"timelimit"				"30"
+				"winlimit"				"5"
+				
+				"end-game"				"1"
+				"allow-tie"				"0"
+				"next-period"				"2"
+			}
+			"2"
+			{
+				"name"					"golden cap"
+				
+				"switch-teams-to-begin"	"1"
+				
+				"windifference"			"1"
+				
+				"end-game"				"1"
+				"allow-tie"				"0"
+				"next-period"			"2"
+			}
+		}
+	}
+	
+	"ozf-koth"
 	{
 		"periods"
 		{
@@ -451,7 +533,8 @@
 			}
 		}
 	}
-	"ozfortress-ctf"
+	
+	"ozf-ctf"
 	{
 		"periods"
 		{
@@ -482,32 +565,52 @@
 			}
 		}
 	}
-	"ozfortress-domination"
+	
+	"ozf-stopwatch"
 	{
 		"periods"
 		{
 			"1"
 			{
-				"name"					"regulation"
+				"name"					"first half"
 				
-				"timelimit"				"30"
-				"winlimit"				"3"
+				"stopwatch"				"1"
 				
-				"end-game"				"1"
-				"allow-tie"				"0"
+				"manual-scoring"		"1"
+				"maxrounds"				"1"
+				
+				"end-game"				"0"
 				"next-period"			"2"
 			}
 			"2"
 			{
-				"name"					"golden cap"
+				"name"					"second half"
 				
 				"switch-teams-to-begin"	"1"
 				
+				"stopwatch"				"1"
+				
+				"manual-scoring"		"1"
+				"maxrounds"				"1"
+				
+				"end-game"				"1"
+				"allow-tie"				"0"
+				"next-period"			"3"
+			}
+			"3"
+			{
+				"name"					"overtime"
+				
+				"switch-teams-to-begin"	"1"
+				
+				"stopwatch"				"1"
+				
+				"manual-scoring"		"1"
 				"windifference"			"1"
 				
 				"end-game"				"1"
 				"allow-tie"				"0"
-				"next-period"			"2"
+				"next-period"			"3"
 			}
 		}
 	}


### PR DESCRIPTION
owl-push and owl-koth for regular owl rounds, allow ties
owl-push-finals and owl-koth-finals don't allow ties
ozf-push and ozf-koth follow more standard scrim configs
ozf-ctf and ozf-stopwatch for legacy competitions
